### PR TITLE
Min throughput support

### DIFF
--- a/src/Bullfrog.Actors.Interfaces/Bullfrog.Actors.Interfaces.csproj
+++ b/src/Bullfrog.Actors.Interfaces/Bullfrog.Actors.Interfaces.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Eshopworld.DevOps" Version="3.0.0" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.654" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.658" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Bullfrog.Actors/Bullfrog.Actors.csproj
+++ b/src/Bullfrog.Actors/Bullfrog.Actors.csproj
@@ -27,14 +27,14 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.2" />
     <PackageReference Include="Autofac.ServiceFabric" Version="2.2.0" />
-    <PackageReference Include="Eshopworld.Telemetry" Version="2.1.3" />
-    <PackageReference Include="IdentityModel" Version="4.0.0-cragganmore" />
+    <PackageReference Include="Eshopworld.Telemetry" Version="2.1.4" />
+    <PackageReference Include="IdentityModel" Version="4.0.0-preview.2.6" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.22.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.8" /> <!-- Microsoft.Rest.ClientRuntime.Azure.Authentication 2.3.4 requires >= 3.14.0 && < 4.0.0-->
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.654" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.658" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bullfrog.Actors/EventModels/CosmosThroughputTooLow.cs
+++ b/src/Bullfrog.Actors/EventModels/CosmosThroughputTooLow.cs
@@ -1,0 +1,19 @@
+﻿using Eshopworld.Core;
+
+namespace Bullfrog.Actors.EventModels
+{
+    public class CosmosThroughputTooLow : TelemetryEvent
+    {
+        public string CosmosAccunt { get; set; }
+
+        public string Database { get; set; }
+
+        public string Container { get; set; }
+
+        public int ThroughputRequired { get; set; }
+
+        public int MinThroughput { get; set; }
+
+        public string ErrorMessage { get; set; }
+    }
+}

--- a/src/Bullfrog.Api/Bullfrog.Api.csproj
+++ b/src/Bullfrog.Api/Bullfrog.Api.csproj
@@ -25,12 +25,12 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />
     <PackageReference Include="Eshopworld.Web" Version="2.1.6" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="2.7.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.10.0-beta3" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.10.0-beta4" />
     <PackageReference Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.654" />
-    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="3.3.654" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.658" />
+    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="3.3.658" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc2" />
   </ItemGroup>
 

--- a/src/Bullfrog.Common/Bullfrog.Common.csproj
+++ b/src/Bullfrog.Common/Bullfrog.Common.csproj
@@ -11,15 +11,15 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.2" />
     <PackageReference Include="Eshopworld.DevOps" Version="3.0.0" />
-    <PackageReference Include="Eshopworld.Telemetry" Version="2.1.3" />
+    <PackageReference Include="Eshopworld.Telemetry" Version="2.1.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric.Native" Version="2.2.2" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.0.0.9-preview" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.0.0.10-preview" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.2.0-preview2" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.2.0-preview3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.654" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.658" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/Bullfrog.Fabric/Bullfrog.Fabric.sfproj
+++ b/src/Bullfrog.Fabric/Bullfrog.Fabric.sfproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets=";ValidateMSBuildFiles">
-  <Import Project="..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
+  <Import Project="..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.8\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.8\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>cf3104c1-2e63-4a0e-a0e1-a3dbc85c926c</ProjectGuid>
     <ProjectVersion>2.4</ProjectVersion>
@@ -51,9 +51,9 @@
     <ApplicationProjectTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Service Fabric Tools\Microsoft.VisualStudio.Azure.Fabric.ApplicationProject.targets</ApplicationProjectTargetsPath>
   </PropertyGroup>
   <Import Project="$(ApplicationProjectTargetsPath)" Condition="Exists('$(ApplicationProjectTargetsPath)')" />
-  <Import Project="..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
-  <Target Name="ValidateMSBuildFiles">
-    <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" Text="Unable to find the '..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.props' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
-    <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" Text="Unable to find the '..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.7\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
+  <Import Project="..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.8\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.8\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
+  <Target Name="ValidateMSBuildFiles" BeforeTargets="PrepareForBuild">
+    <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.8\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" Text="Unable to find the '..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.8\build\Microsoft.VisualStudio.Azure.Fabric.Application.props' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
+    <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.8\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" Text="Unable to find the '..\..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.8\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
   </Target>
 </Project>

--- a/src/Bullfrog.Fabric/packages.config
+++ b/src/Bullfrog.Fabric/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.6.7" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.6.8" targetFramework="net472" />
 </packages>

--- a/src/Tests/Bullfrog.Tests.Integration/Bullfrog.Tests.Integration.csproj
+++ b/src/Tests/Bullfrog.Tests.Integration/Bullfrog.Tests.Integration.csproj
@@ -16,9 +16,9 @@
     <PackageReference Include="EShopworld.Security.Services.Rest" Version="2.0.3" />
     <PackageReference Include="EShopworld.Security.Services.Testing" Version="1.0.3" />
     <PackageReference Include="Eshopworld.Tests.Core" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.2.0-preview2" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.2.0-preview3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Bullfrog.Tests/Bullfrog.Tests.csproj
+++ b/src/Tests/Bullfrog.Tests/Bullfrog.Tests.csproj
@@ -16,9 +16,9 @@
     <PackageReference Include="Eshopworld.Tests.Core" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="ServiceFabric.Mocks" Version="3.4.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="Moq" Version="4.11.0-rc1" />
+    <PackageReference Include="ServiceFabric.Mocks" Version="3.4.12" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Bullfrog.Tests/ExternalComponents/ComponentsTestFixture.cs
+++ b/src/Tests/Bullfrog.Tests/ExternalComponents/ComponentsTestFixture.cs
@@ -5,8 +5,10 @@ using Autofac;
 using Bullfrog.Actors.Helpers;
 using Bullfrog.Common;
 using Bullfrog.Common.DependencyInjection;
+using Eshopworld.Core;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
+using Moq;
 using Xunit;
 
 namespace ExternalComponents
@@ -19,6 +21,8 @@ namespace ExternalComponents
 
         public IContainer Container { get; private set; }
 
+        public Mock<IBigBrother> BigBrotherMock { get; private set; }
+
         public ComponentsTestFixture()
         {
             if (String.IsNullOrEmpty(Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")))
@@ -30,6 +34,8 @@ namespace ExternalComponents
         {
             if (Container == null)
             {
+                BigBrotherMock = new Mock<IBigBrother>();
+
                 var builder = new ContainerBuilder();
                 builder.RegisterInstance(_configuration)
                       .As<IConfigurationRoot>()
@@ -37,6 +43,7 @@ namespace ExternalComponents
                 builder.RegisterModule<AzureManagementFluentModule>();
                 builder.RegisterType<ScaleSetManager>().As<IScaleSetManager>();
                 builder.RegisterType<CosmosManager>().As<ICosmosManager>();
+                builder.RegisterInstance<IBigBrother>(BigBrotherMock.Object);
                 Container = builder.Build();
             }
         }


### PR DESCRIPTION
Min throughput of a Cosmos database can be changed after the database is scaled out. In this case Bullfrog might not be able to reset the throughput to its lowest level. The workaround here uses the error message to find out the current valid min throughput. The current version cosmos client library does not provide support for getting this value.
