### PR TITLE
Fixed calculation of scale set instances

### DIFF
--- a/src/Bullfrog.Actors/Helpers/ScaleSetManager.cs
+++ b/src/Bullfrog.Actors/Helpers/ScaleSetManager.cs
@@ -28,9 +28,11 @@ namespace Bullfrog.Actors.Helpers
 
             await UpdateProfile(configuration, profile =>
             {
-                if (instances > profile.MaxInstanceCount)
-                    instances = profile.MaxInstanceCount;
-                return (instances, instances);
+                instances = Math.Min(profile.MaxInstanceCount,
+                    Math.Max(instances, _configuration.MinInstanceCount));
+                var defaultInstances = Math.Min(profile.MaxInstanceCount,
+                    Math.Max(instances, _configuration.DefaultInstanceCount));
+                return (instances, defaultInstances);
             }, cancellationToken);
 
             return instances;

--- a/src/Bullfrog.Actors/Helpers/ScaleSetManager.cs
+++ b/src/Bullfrog.Actors/Helpers/ScaleSetManager.cs
@@ -29,9 +29,9 @@ namespace Bullfrog.Actors.Helpers
             await UpdateProfile(configuration, profile =>
             {
                 instances = Math.Min(profile.MaxInstanceCount,
-                    Math.Max(instances, _configuration.MinInstanceCount));
+                    Math.Max(instances, configuration.MinInstanceCount));
                 var defaultInstances = Math.Min(profile.MaxInstanceCount,
-                    Math.Max(instances, _configuration.DefaultInstanceCount));
+                    Math.Max(instances, configuration.DefaultInstanceCount));
                 return (instances, defaultInstances);
             }, cancellationToken);
 


### PR DESCRIPTION
The previous code ignored the minimal number of instances of a scale set provided by its configuration when scaling out.