### PR TITLE
Cloning autoscale setting profile instead of modifying the default one

### DIFF
--- a/src/Bullfrog.Actors.Interfaces/Models/ScaleSetConfiguration.cs
+++ b/src/Bullfrog.Actors.Interfaces/Models/ScaleSetConfiguration.cs
@@ -99,17 +99,19 @@ namespace Bullfrog.Actors.Interfaces.Models
 
             if (!autoscale.Profiles.TryGetValue(ProfileName, out var profile))
             {
-                var message = $"The autoscale settings {AutoscaleSettingsResourceId} had no \"{ProfileName}\" profile";
+                var message = $"The autoscale setting {AutoscaleSettingsResourceId} had no \"{ProfileName}\" profile.";
+                return new ValidationResult(message, new[] { nameof(ProfileName) });
+            }
+
+            if(profile.Rules.Count == 0)
+            {
+                var message = $"The profile {ProfileName} in the autoscale setting {AutoscaleSettingsResourceId} is not based on a metric.";
                 return new ValidationResult(message, new[] { nameof(ProfileName) });
             }
 
             try
             {
-                await azure.UpdateAutoscaleProfile(
-                    AutoscaleSettingsResourceId,
-                    ProfileName,
-                    pr => (pr.MinInstanceCount, pr.DefaultInstanceCount), // keep values the same
-                    forceUpdate: true);
+                await autoscale.Update().ApplyAsync();
             }
             catch (Exception ex)
             {

--- a/src/Bullfrog.Actors/EventModels/AzureOperationDurationEvent.cs
+++ b/src/Bullfrog.Actors/EventModels/AzureOperationDurationEvent.cs
@@ -5,5 +5,7 @@
         public string ResourceId { get; set; }
 
         public string Operation { get; set; }
+
+        public string ExceptionMessage { get; set; }
     }
 }

--- a/src/Bullfrog.Actors/EventModels/CosmosThroughputTooLow.cs
+++ b/src/Bullfrog.Actors/EventModels/CosmosThroughputTooLow.cs
@@ -4,7 +4,7 @@ namespace Bullfrog.Actors.EventModels
 {
     public class CosmosThroughputTooLow : TelemetryEvent
     {
-        public string CosmosAccunt { get; set; }
+        public string CosmosAccount { get; set; }
 
         public string Database { get; set; }
 

--- a/src/Bullfrog.Actors/ResourceScalers/ControlPlaneCosmosScaler.cs
+++ b/src/Bullfrog.Actors/ResourceScalers/ControlPlaneCosmosScaler.cs
@@ -20,9 +20,9 @@ namespace Bullfrog.Actors.ResourceScalers
             _bigBrother = bigBrother;
         }
 
-        public override async Task<int?> ScaleIn()
+        public override async Task<bool> ScaleIn()
         {
-            return await SetThroughput(null);
+            return await SetThroughput(null) != null;
         }
 
         public override async Task<int?> ScaleOut(int throughput, DateTimeOffset endsAt)
@@ -51,7 +51,7 @@ namespace Bullfrog.Actors.ResourceScalers
                 {
                     _bigBrother.Publish(new CosmosThroughputTooLow
                     {
-                        CosmosAccunt = _cosmosConfiguration.Name,
+                        CosmosAccount = _cosmosConfiguration.Name,
                         ErrorMessage = ex.Message,
                         MinThroughput = ex.MinimumThroughput,
                         ThroughputRequired = requestUnits,

--- a/src/Bullfrog.Actors/ResourceScalers/ControlPlaneCosmosScaler.cs
+++ b/src/Bullfrog.Actors/ResourceScalers/ControlPlaneCosmosScaler.cs
@@ -20,9 +20,19 @@ namespace Bullfrog.Actors.ResourceScalers
             _bigBrother = bigBrother;
         }
 
-        public override async Task<int?> SetThroughput(int? newThroughput)
+        public override async Task<int?> ScaleIn()
         {
-            var newRequestUnits = (int)((newThroughput ?? 0) * _cosmosConfiguration.RequestUnitsPerRequest);
+            return await SetThroughput(null);
+        }
+
+        public override async Task<int?> ScaleOut(int throughput, DateTimeOffset endsAt)
+        {
+            return await SetThroughput(throughput);
+        }
+
+        private async Task<int?> SetThroughput(int? throughput)
+        {
+            var newRequestUnits = (int)((throughput ?? 0) * _cosmosConfiguration.RequestUnitsPerRequest);
             var roundedRequestUnits = (newRequestUnits + 99) / 100 * 100;
 
             var requestUnits = Math.Max(roundedRequestUnits, _cosmosConfiguration.MinimumRU);

--- a/src/Bullfrog.Actors/ResourceScalers/CosmosScaler.cs
+++ b/src/Bullfrog.Actors/ResourceScalers/CosmosScaler.cs
@@ -20,9 +20,9 @@ namespace Bullfrog.Actors.ResourceScalers
             _bigBrother = bigBrother;
         }
 
-        public override async Task<int?> ScaleIn()
+        public override async Task<bool> ScaleIn()
         {
-            return await SetThroughput(null);
+            return await SetThroughput(null) != null;
         }
 
         public override async Task<int?> ScaleOut(int throughput, DateTimeOffset endsAt)

--- a/src/Bullfrog.Actors/ResourceScalers/CosmosScaler.cs
+++ b/src/Bullfrog.Actors/ResourceScalers/CosmosScaler.cs
@@ -20,13 +20,23 @@ namespace Bullfrog.Actors.ResourceScalers
             _bigBrother = bigBrother;
         }
 
-        public override async Task<int?> SetThroughput(int? newThroughput)
+        public override async Task<int?> ScaleIn()
+        {
+            return await SetThroughput(null);
+        }
+
+        public override async Task<int?> ScaleOut(int throughput, DateTimeOffset endsAt)
+        {
+            return await SetThroughput(throughput);
+        }
+
+        private async Task<int?> SetThroughput(int? throughput)
         {
             var currentThroughput = await _throughputClient.Get();
             if (currentThroughput.IsThroughputChangePending)
                 return null;
 
-            var newRequestUnits = (int)((newThroughput ?? 0) * _cosmosConfiguration.RequestUnitsPerRequest);
+            var newRequestUnits = (int)((throughput ?? 0) * _cosmosConfiguration.RequestUnitsPerRequest);
             var roundedRequestUnits = (newRequestUnits + 99) / 100 * 100;
 
             var requestUnits = Math.Max(roundedRequestUnits, _cosmosConfiguration.MinimumRU);

--- a/src/Bullfrog.Actors/ResourceScalers/ResourceScaler.cs
+++ b/src/Bullfrog.Actors/ResourceScalers/ResourceScaler.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Bullfrog.Actors.ResourceScalers
 {
@@ -8,12 +9,17 @@ namespace Bullfrog.Actors.ResourceScalers
     public abstract class ResourceScaler
     {
         /// <summary>
-        /// Attempts to change throughput.
+        /// Starts the scale out operation.
         /// </summary>
-        /// <param name="newThroughput">The new throughput.</param>
-        /// <returns>The throughput available if the operation completed,
-        /// null if scaling is in progress (in which case the method should
-        /// be called again after some delay)</returns>
-        public abstract Task<int?> SetThroughput(int? newThroughput);
+        /// <param name="throughput">The requested throughput.</param>
+        /// <param name="endsAt">The end scale out period hint.</param>
+        /// <returns>The final throughput value or null if the operation has not completed yet.</returns>
+        public abstract Task<int?> ScaleOut(int throughput, DateTimeOffset endsAt);
+
+        /// <summary>
+        /// Starts the scale in operation.
+        /// </summary>
+        /// <returns>The final throughput value or null if the operation has not completed yet.</returns>
+        public abstract Task<int?> ScaleIn();
     }
 }

--- a/src/Bullfrog.Actors/ResourceScalers/ResourceScaler.cs
+++ b/src/Bullfrog.Actors/ResourceScalers/ResourceScaler.cs
@@ -19,7 +19,7 @@ namespace Bullfrog.Actors.ResourceScalers
         /// <summary>
         /// Starts the scale in operation.
         /// </summary>
-        /// <returns>The final throughput value or null if the operation has not completed yet.</returns>
-        public abstract Task<int?> ScaleIn();
+        /// <returns>Returns true if operation has completed or false if the request should be repeated after some delay.</returns>
+        public abstract Task<bool> ScaleIn();
     }
 }

--- a/src/Bullfrog.Actors/ResourceScalers/ScaleSetScaler.cs
+++ b/src/Bullfrog.Actors/ResourceScalers/ScaleSetScaler.cs
@@ -52,8 +52,12 @@ namespace Bullfrog.Actors.ResourceScalers
                     _dateTime.UtcNow, endsAt);
             });
 
-            var workingInstances = await _scaleSetMonitor.GetNumberOfWorkingInstances(
-               _configuration.LoadBalancerResourceId, _configuration.HealthPortPort);
+            int workingInstances = 0;
+            await LogAzureCallDuration(_bigBrother, "GetNumberOfInstances", _configuration.LoadBalancerResourceId, async () =>
+            {
+                workingInstances = await _scaleSetMonitor.GetNumberOfWorkingInstances(
+                  _configuration.LoadBalancerResourceId, _configuration.HealthPortPort);
+            });
             if (instances < workingInstances)
             {
                 var usableInstances = Math.Max(workingInstances - _configuration.ReservedInstances, 0);

--- a/src/Bullfrog.Actors/ScaleManager.cs
+++ b/src/Bullfrog.Actors/ScaleManager.cs
@@ -577,7 +577,7 @@ namespace Bullfrog.Actors
         [DataContract]
         [KnownType(typeof(ScaleOutRequest))]
         [KnownType(typeof(ScaleInRequest))]
-        private class ScaleRequest
+        private abstract class ScaleRequest
         {
             private static readonly TimeSpan DefaultErrorDelay = TimeSpan.FromMinutes(1);
             private static readonly TimeSpan MaxErrorDelay = TimeSpan.FromMinutes(5);
@@ -591,11 +591,11 @@ namespace Bullfrog.Actors
             [DataMember]
             public DateTimeOffset OperationStarted { get; set; }
 
-            public virtual bool IsExecuting => false;
+            public abstract bool IsExecuting { get; }
 
-            public virtual int? CompletedThroughput => null;
+            public abstract int? CompletedThroughput { get; }
 
-            protected virtual ScaleRequestStatus CompletionStatus => ScaleRequestStatus.Completed;
+            protected abstract ScaleRequestStatus CompletionStatus { get; }
 
             public ScaleRequestStatus Status
             {
@@ -646,20 +646,11 @@ namespace Bullfrog.Actors
                 }
             }
 
-            protected virtual void UpdateCompletionEvent(ResourceScalingCompleted ev)
-            {
-            }
+            protected abstract void UpdateCompletionEvent(ResourceScalingCompleted ev);
 
-            protected virtual string OperationDescription(string resourceName)
-            {
-                throw new NotImplementedException();
-            }
+            protected abstract string OperationDescription(string resourceName);
 
-            protected virtual Task ProcessRequest(ResourceScaler scaler)
-            {
-                // This code is only temporary. This method will be abstract.
-                throw new NotImplementedException("Old ScaleRequest");
-            }
+            protected abstract Task ProcessRequest(ResourceScaler scaler);
 
             private void RegisterError(DateTimeOffset now)
             {
@@ -681,6 +672,7 @@ namespace Bullfrog.Actors
             }
         }
 
+        [DataContract]
         private class ScaleOutRequest : ScaleRequest
         {
             private static readonly TimeSpan EndsAtHintDelay = TimeSpan.FromMinutes(3);
@@ -724,6 +716,7 @@ namespace Bullfrog.Actors
                 => $"scale out {resourceName} to {RequestedThroughput}";
         }
 
+        [DataContract]
         private class ScaleInRequest : ScaleRequest
         {
             [DataMember]
@@ -747,6 +740,10 @@ namespace Bullfrog.Actors
 
             protected override string OperationDescription(string resourceName)
                 => $"scale in {resourceName}";
+
+            protected override void UpdateCompletionEvent(ResourceScalingCompleted ev)
+            {
+            }
         }
     }
 }

--- a/src/Bullfrog.Common/AzureFluentExtensions.cs
+++ b/src/Bullfrog.Common/AzureFluentExtensions.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Management.Fluent;
 using Microsoft.Azure.Management.Monitor.Fluent;
+using Microsoft.Azure.Management.Monitor.Fluent.AutoscaleProfile.UpdateDefinition;
 using Microsoft.Azure.Management.Monitor.Fluent.Models;
 
 namespace Bullfrog.Common
@@ -12,44 +14,61 @@ namespace Bullfrog.Common
     /// </summary>
     public static class AzureFluentExtensions
     {
-        /// <summary>
-        /// Updadates the minimal and default number of instances in the specified autoscale settings profile
-        /// </summary>
-        /// <param name="azure">The azure management client.</param>
-        /// <param name="autoscaleSettingsResourceId">The resource ID of the autoscale settings.</param>
-        /// <param name="profileName">The name of the profile to modify.</param>
-        /// <param name="instanceCalculator">The function which based on the current profile returns new values of changed profile's properties.</param>
-        /// <param name="forceUpdate">Specifies whether the profile should be updated even if the new values equal to existing.</param>
-        /// <param name="cancellationToken">The cancellation toke.</param>
-        /// <returns></returns>
-        public static async Task<IAzure> UpdateAutoscaleProfile(
+        private const string BullfrogProfileName = "BullfrogProfile";
+
+        public static async Task<IAzure> SaveBullfrogProfile(
             this IAzure azure,
             string autoscaleSettingsResourceId,
-            string profileName,
+            string defaultProfileName,
             Func<IAutoscaleProfile, (int minInstance, int defaultInstances)> instanceCalculator,
-            bool forceUpdate = false,
             CancellationToken cancellationToken = default)
         {
             var autoscale = await azure.AutoscaleSettings.ValidateAccessAsync(autoscaleSettingsResourceId, cancellationToken);
-            if (!autoscale.Profiles.TryGetValue(profileName, out var profile))
+            if (!autoscale.Profiles.TryGetValue(defaultProfileName, out var defaultProfile))
             {
-                throw new BullfrogException($"The profile {profileName} has not been found in the autoscale settings {autoscaleSettingsResourceId}.");
+                throw new BullfrogException($"The profile {defaultProfileName} has not been found in the autoscale settings {autoscaleSettingsResourceId}.");
             }
 
-            var (minInstance, defaultInstances) = instanceCalculator(profile);
+            var (minInstance, defaultInstances) = instanceCalculator(defaultProfile);
 
-            if (forceUpdate
-                || profile.MinInstanceCount != minInstance
-                || profile.DefaultInstanceCount != defaultInstances)
+            if (autoscale.Profiles.TryGetValue(BullfrogProfileName, out var bullfrogProfile))
+            {
+                if (bullfrogProfile.MinInstanceCount != minInstance || bullfrogProfile.DefaultInstanceCount != defaultInstances)
+                {
+                    await autoscale.Update()
+                         .UpdateAutoscaleProfile(BullfrogProfileName)
+                         .WithMetricBasedScale(minInstance, defaultProfile.MaxInstanceCount, defaultInstances)
+                         .Parent()
+                         .ApplyAsync();
+                }
+            }
+            else
             {
                 await autoscale.Update()
-                    .UpdateAutoscaleProfile(profileName)
-                    .WithMetricBasedScale(minInstance, profile.MaxInstanceCount, defaultInstances)
-                    .Parent()
+                    .DefineAutoscaleProfile(BullfrogProfileName)
+                    .WithMetricBasedScale(minInstance, defaultProfile.MaxInstanceCount, defaultInstances)
+                    .AddRules(defaultProfile.Rules)
+                    .Attach()
                     .ApplyAsync();
             }
 
             return azure;
+        }
+
+        public static async Task<IAutoscaleSetting> RemoveBullfrogProfile(
+            this IAzure azure,
+            string autoscaleSettingsResourceId,
+            CancellationToken cancellationToken = default)
+        {
+            var autoscale = await azure.AutoscaleSettings.ValidateAccessAsync(autoscaleSettingsResourceId, cancellationToken);
+            if (autoscale.Profiles.ContainsKey(BullfrogProfileName))
+            {
+                return await autoscale.Update()
+                    .WithoutAutoscaleProfile(BullfrogProfileName)
+                    .ApplyAsync();
+            }
+
+            return autoscale;
         }
 
         /// <summary>
@@ -76,6 +95,26 @@ namespace Bullfrog.Common
             {
                 throw new BullfrogException($"Failed to access autoscale settings {resourceId}: {ex.Message}");
             }
+        }
+
+        private static IWithScaleRuleOptional AddRules(this IWithScaleRule profile, IEnumerable<IScaleRule> rules)
+        {
+            IWithScaleRuleOptional ruleOptional = null;
+            foreach (var rule in rules)
+            {
+                ruleOptional = (ruleOptional?.DefineScaleRule() ?? profile.DefineScaleRule())
+                    .WithMetricSource(rule.MetricSource)
+                    .WithMetricName(rule.MetricName)
+                    .WithStatistic(rule.Duration, rule.Frequency, rule.FrequencyStatistic)
+                    .WithCondition(rule.TimeAggregation, rule.Condition, rule.Threshold)
+                    .WithScaleAction(rule.ScaleDirection, rule.ScaleType, rule.ScaleInstanceCount, rule.CoolDown)
+                    .Attach();
+            }
+
+            if (ruleOptional == null)
+                throw new ArgumentException("The list of rules must not be empty.");
+
+            return ruleOptional;
         }
     }
 }

--- a/src/Tests/Bullfrog.Tests/BaseApiTests.cs
+++ b/src/Tests/Bullfrog.Tests/BaseApiTests.cs
@@ -185,7 +185,7 @@ public class BaseApiTests : IDisposable
         scalerMoq.Setup(x => x.ScaleOut(It.IsAny<int>(), It.IsAny<DateTimeOffset>()))
             .ReturnsAsync((int?)null);
         scalerMoq.Setup(x => x.ScaleIn())
-            .ReturnsAsync((int?)null);
+            .ReturnsAsync(true);
         ScalerFactoryMoq.Setup(x => x.CreateScaler(It.IsAny<string>(), It.IsAny<ScaleManagerConfiguration>()))
             .Returns(scalerMoq.Object);
     }
@@ -203,7 +203,7 @@ public class BaseApiTests : IDisposable
         scalerMoq.Setup(x => x.ScaleOut(It.IsAny<int>(), It.IsAny<DateTimeOffset>()))
             .Returns((int n, DateTimeOffset dt) => Task.FromResult(CalculateAndSaveThroughput(n)));
         scalerMoq.Setup(x => x.ScaleIn())
-            .Returns(() => Task.FromResult(CalculateAndSaveThroughput(null)));
+            .Returns(() => Task.FromResult(CalculateAndSaveThroughput(null) != null));
         ScalerFactoryMoq.Setup(x => x.CreateScaler(name, It.IsAny<ScaleManagerConfiguration>()))
             .Returns(scalerMoq.Object);
         ScaleHistory[name] = new List<(TimeSpan SinceStart, int? RequestedThroughput, int? ReachedThroughput)>();
@@ -289,10 +289,10 @@ public class BaseApiTests : IDisposable
             _logSetThroughputAction = logSetThroughputAction;
         }
 
-        public override async Task<int?> ScaleIn()
+        public override async Task<bool> ScaleIn()
         {
             var result = await _scaler.ScaleIn();
-            _logSetThroughputAction(null, result);
+            _logSetThroughputAction(null, result ? 1 : 0);
             return result;
         }
 

--- a/src/Tests/Bullfrog.Tests/ControlPlaneCosmosScalerTests.cs
+++ b/src/Tests/Bullfrog.Tests/ControlPlaneCosmosScalerTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Bullfrog.Actors.Interfaces.Models;
 using Bullfrog.Actors.ResourceScalers;
@@ -30,7 +28,7 @@ public class ControlPlaneCosmosScalerTests
         var bigBrother = new Mock<IBigBrother>();
         var scaler = new ControlPlaneCosmosScaler(throughputClientMoq.Object, cosmosConfiguration, bigBrother.Object);
 
-        var result = await scaler.SetThroughput(21);
+        var result = await scaler.ScaleOut(21, DateTimeOffset.MaxValue);
 
         result.Should().Be(50);
     }
@@ -50,7 +48,7 @@ public class ControlPlaneCosmosScalerTests
         var bigBrother = new Mock<IBigBrother>();
         var scaler = new ControlPlaneCosmosScaler(throughputClientMoq.Object, cosmosConfiguration, bigBrother.Object);
 
-        var result = await scaler.SetThroughput(72);
+        var result = await scaler.ScaleOut(72, DateTimeOffset.MaxValue);
 
         result.Should().Be(70);
     }
@@ -70,7 +68,7 @@ public class ControlPlaneCosmosScalerTests
         var bigBrother = new Mock<IBigBrother>();
         var scaler = new ControlPlaneCosmosScaler(throughputClientMoq.Object, cosmosConfiguration, bigBrother.Object);
 
-        var result = await scaler.SetThroughput(55);
+        var result = await scaler.ScaleOut(55, DateTimeOffset.MaxValue);
 
         result.Should().Be(60);
     }
@@ -92,7 +90,7 @@ public class ControlPlaneCosmosScalerTests
         var bigBrother = new Mock<IBigBrother>();
         var scaler = new ControlPlaneCosmosScaler(throughputClientMoq.Object, cosmosConfiguration, bigBrother.Object);
 
-        var result = await scaler.SetThroughput(30);
+        var result = await scaler.ScaleOut(30, DateTimeOffset.MaxValue);
 
         result.Should().Be(60);
     }
@@ -111,7 +109,7 @@ public class ControlPlaneCosmosScalerTests
         var bigBrother = new Mock<IBigBrother>();
         var scaler = new ControlPlaneCosmosScaler(throughputClientMoq.Object, cosmosConfiguration, bigBrother.Object);
 
-        var result = await scaler.SetThroughput(45);
+        var result = await scaler.ScaleOut(45, DateTimeOffset.MaxValue);
 
         result.Should().Be(50);
     }

--- a/src/Tests/Bullfrog.Tests/CosmosScalerTests.cs
+++ b/src/Tests/Bullfrog.Tests/CosmosScalerTests.cs
@@ -32,11 +32,18 @@ public class CosmosScalerTests
         };
         var scaler = new CosmosScaler(cosmosThroughputClinetMoq.Object, configuration, BigBrotherMoq.Object);
 
-        var result = newThroughput.HasValue
-            ? await scaler.ScaleOut(newThroughput.Value, DateTimeOffset.MaxValue)
-            : await scaler.ScaleIn();
+        if (newThroughput.HasValue)
+        {
+            var result = await scaler.ScaleOut(newThroughput.Value, DateTimeOffset.MaxValue);
 
-        result.Should().Be(40);
+            result.Should().Be(40);
+        }
+        else
+        {
+            await scaler.ScaleIn();
+        }
+
+        cosmosThroughputClinetMoq.VerifyAll();
     }
 
     [Theory, IsLayer0]
@@ -58,11 +65,18 @@ public class CosmosScalerTests
         };
         var scaler = new CosmosScaler(cosmosThroughputClinetMoq.Object, configuration, BigBrotherMoq.Object);
 
-        var result = newThroughput.HasValue
-           ? await scaler.ScaleOut(newThroughput.Value, DateTimeOffset.MaxValue)
-           : await scaler.ScaleIn();
+        if(newThroughput.HasValue)
+        {
+            var result = await scaler.ScaleOut(newThroughput.Value, DateTimeOffset.MaxValue);
 
-        result.Should().Be(30);
+            result.Should().Be(30);
+        }
+        else
+        {
+            await scaler.ScaleIn();
+        }
+
+        cosmosThroughputClinetMoq.VerifyAll();
     }
 
     [Theory, IsLayer0]
@@ -84,11 +98,18 @@ public class CosmosScalerTests
         };
         var scaler = new CosmosScaler(cosmosThroughputClinetMoq.Object, configuration, BigBrotherMoq.Object);
 
-        var result = newThroughput.HasValue
-        ? await scaler.ScaleOut(newThroughput.Value, DateTimeOffset.MaxValue)
-        : await scaler.ScaleIn();
+        if (newThroughput.HasValue)
+        {
+            var result = await scaler.ScaleOut(newThroughput.Value, DateTimeOffset.MaxValue);
 
-        result.Should().BeNull();
+            result.Should().BeNull();
+        }
+        else
+        {
+            await scaler.ScaleIn();
+        }
+
+        cosmosThroughputClinetMoq.VerifyAll();
     }
 
     [Theory, IsLayer0]
@@ -115,11 +136,18 @@ public class CosmosScalerTests
         };
         var scaler = new CosmosScaler(cosmosThroughputClinetMoq.Object, configuration, BigBrotherMoq.Object);
 
-        var result = newThroughput.HasValue
-       ? await scaler.ScaleOut(newThroughput.Value, DateTimeOffset.MaxValue)
-       : await scaler.ScaleIn();
+        if (newThroughput.HasValue)
+        {
+            var result = await scaler.ScaleOut(newThroughput.Value, DateTimeOffset.MaxValue);
 
-        result.Should().Be(setValue / 10);
+            result.Should().Be(setValue / 10);
+        }
+        else
+        {
+            await scaler.ScaleIn();
+        }
+
+        cosmosThroughputClinetMoq.VerifyAll();
     }
 
     [Fact, IsLayer0]

--- a/src/Tests/Bullfrog.Tests/CosmosScalerTests.cs
+++ b/src/Tests/Bullfrog.Tests/CosmosScalerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Bullfrog.Actors.Interfaces.Models;
 using Bullfrog.Actors.ResourceScalers;
 using Bullfrog.Common.Cosmos;
@@ -31,7 +32,9 @@ public class CosmosScalerTests
         };
         var scaler = new CosmosScaler(cosmosThroughputClinetMoq.Object, configuration, BigBrotherMoq.Object);
 
-        var result = await scaler.SetThroughput(newThroughput);
+        var result = newThroughput.HasValue
+            ? await scaler.ScaleOut(newThroughput.Value, DateTimeOffset.MaxValue)
+            : await scaler.ScaleIn();
 
         result.Should().Be(40);
     }
@@ -55,7 +58,9 @@ public class CosmosScalerTests
         };
         var scaler = new CosmosScaler(cosmosThroughputClinetMoq.Object, configuration, BigBrotherMoq.Object);
 
-        var result = await scaler.SetThroughput(newThroughput);
+        var result = newThroughput.HasValue
+           ? await scaler.ScaleOut(newThroughput.Value, DateTimeOffset.MaxValue)
+           : await scaler.ScaleIn();
 
         result.Should().Be(30);
     }
@@ -79,7 +84,9 @@ public class CosmosScalerTests
         };
         var scaler = new CosmosScaler(cosmosThroughputClinetMoq.Object, configuration, BigBrotherMoq.Object);
 
-        var result = await scaler.SetThroughput(newThroughput);
+        var result = newThroughput.HasValue
+        ? await scaler.ScaleOut(newThroughput.Value, DateTimeOffset.MaxValue)
+        : await scaler.ScaleIn();
 
         result.Should().BeNull();
     }
@@ -108,7 +115,9 @@ public class CosmosScalerTests
         };
         var scaler = new CosmosScaler(cosmosThroughputClinetMoq.Object, configuration, BigBrotherMoq.Object);
 
-        var result = await scaler.SetThroughput(newThroughput);
+        var result = newThroughput.HasValue
+       ? await scaler.ScaleOut(newThroughput.Value, DateTimeOffset.MaxValue)
+       : await scaler.ScaleIn();
 
         result.Should().Be(setValue / 10);
     }
@@ -130,7 +139,7 @@ public class CosmosScalerTests
         };
         var scaler = new CosmosScaler(cosmosThroughputClinetMoq.Object, configuration, BigBrotherMoq.Object);
 
-        var result = await scaler.SetThroughput(50);
+        var result = await scaler.ScaleOut(50, DateTimeOffset.MaxValue);
 
         result.Should().BeNull();
     }
@@ -150,7 +159,7 @@ public class CosmosScalerTests
         };
         var scaler = new CosmosScaler(cosmosThroughputClinetMoq.Object, configuration, BigBrotherMoq.Object);
 
-        var result = await scaler.SetThroughput(60);
+        var result = await scaler.ScaleOut(60, DateTimeOffset.MaxValue);
 
         result.Should().Be(60);
     }

--- a/src/Tests/Bullfrog.Tests/TestScalers/DelayTestScaler.cs
+++ b/src/Tests/Bullfrog.Tests/TestScalers/DelayTestScaler.cs
@@ -20,7 +20,17 @@ namespace TestScalers
             _currentThroughput = minThroughput;
         }
 
-        public override Task<int?> SetThroughput(int? newThroughput)
+        public override Task<int?> ScaleIn()
+        {
+            return SetThroughput(null);
+        }
+
+        public override Task<int?> ScaleOut(int throughput, DateTimeOffset validTill)
+        {
+            return SetThroughput(throughput);
+        }
+
+        private Task<int?> SetThroughput(int? newThroughput)
         {
             if (_currentThroughput != (newThroughput ?? _minThroughput))
             {

--- a/src/Tests/Bullfrog.Tests/TestScalers/DelayTestScaler.cs
+++ b/src/Tests/Bullfrog.Tests/TestScalers/DelayTestScaler.cs
@@ -20,9 +20,9 @@ namespace TestScalers
             _currentThroughput = minThroughput;
         }
 
-        public override Task<int?> ScaleIn()
+        public override async Task<bool> ScaleIn()
         {
-            return SetThroughput(null);
+            return await SetThroughput(null) != null;
         }
 
         public override Task<int?> ScaleOut(int throughput, DateTimeOffset validTill)


### PR DESCRIPTION
This PR changes the method used to modify a scale set. Previously the number of instances of a scale set was changed by modifying the minimum instance count (and default instance count) of the specified default profile of a autoscale setting. The new method creates a time-bound copy of the default profile with the modified minimum instance count. During the scale in operation the Bullfrog specific profile is deleted.

Internally the SetThroughput operation of a ResourceScaler class has been replaced by ScaleOut/ScaleIn methods. Mostly because the ScaleOut method needs another parameter and the ScaleIn method don't need to return throughput.