### PR TITLE
Improved error handling

### DIFF
--- a/src/Bullfrog.Actors/Program.cs
+++ b/src/Bullfrog.Actors/Program.cs
@@ -48,7 +48,7 @@ namespace Bullfrog.Actors
                         configuration.TelemetryInitializers.Add(initializer);
                     }
 
-                    foreach(var modules in c.Resolve<IEnumerable<ITelemetryModule>>())
+                    foreach (var modules in c.Resolve<IEnumerable<ITelemetryModule>>())
                     {
                         modules.Initialize(configuration);
                     }

--- a/src/Bullfrog.Common/Bullfrog.Common.csproj
+++ b/src/Bullfrog.Common/Bullfrog.Common.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="Eshopworld.DevOps" Version="4.1.0" />
+    <PackageReference Include="Eshopworld.DevOps" Version="4.2.0" />
     <PackageReference Include="Eshopworld.Messaging" Version="1.1.1" />
     <PackageReference Include="Eshopworld.Telemetry" Version="2.1.5" />
     <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric.Native" Version="2.3.1" />

--- a/src/Tests/Bullfrog.Tests.Integration/Bullfrog.Tests.Integration.csproj
+++ b/src/Tests/Bullfrog.Tests.Integration/Bullfrog.Tests.Integration.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eshopworld.DevOps" Version="4.1.0" />
+    <PackageReference Include="Eshopworld.DevOps" Version="4.2.0" />
     <PackageReference Include="EShopworld.Security.Services.Rest" Version="3.1.1" />
     <PackageReference Include="EShopworld.Security.Services.Testing" Version="1.0.3" />
     <PackageReference Include="Eshopworld.Tests.Core" Version="1.1.1" />


### PR DESCRIPTION
When an exception is not handled by a method triggered by a reminder, a reminder is reset to repeat execution.
When an error happens during the ReportScaleEventState call the list of changes is preserved and another attempt is scheduled.