### PR TITLE
Added logging of model validation errors.

### DIFF
--- a/src/Bullfrog.Actors.Interfaces/IConfigurationManager.cs
+++ b/src/Bullfrog.Actors.Interfaces/IConfigurationManager.cs
@@ -57,6 +57,14 @@ namespace Bullfrog.Actors.Interfaces
         Task<List<ScheduledScaleEvent>> ListScaleEvents(string scaleGroup);
 
         /// <summary>
+        /// Lists scale events.
+        /// </summary>
+        /// <param name="scaleGroup">The name of the scale group</param>
+        /// <param name="parameters">The additional parameters</param>
+        /// <returns>The list of scale events.</returns>
+        Task<List<ScheduledScaleEvent>> ListScheduledScaleEvents(string scaleGroup, ListScaleEventsParameters parameters);
+
+        /// <summary>
         /// Removes the specified scale event.
         /// </summary>
         /// <param name="scaleGroup">The scale group name.</param>

--- a/src/Bullfrog.Actors.Interfaces/IScaleManager.cs
+++ b/src/Bullfrog.Actors.Interfaces/IScaleManager.cs
@@ -22,6 +22,12 @@ namespace Bullfrog.Actors.Interfaces
         Task ScheduleScaleEvent(RegionScaleEvent scaleEvent);
 
         /// <summary>
+        /// Returns the list of events.
+        /// </summary>
+        /// <returns></returns>
+        Task<List<RegionScaleEvent>> ListEvents();
+
+        /// <summary>
         /// Removes the specified scale event.
         /// </summary>
         /// <param name="id">The scale event to remove.</param>

--- a/src/Bullfrog.Actors.Interfaces/Models/ListScaleEventsParameters.cs
+++ b/src/Bullfrog.Actors.Interfaces/Models/ListScaleEventsParameters.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Azure.Management.AppService.Fluent.Models;
+
+namespace Bullfrog.Actors.Interfaces.Models
+{
+    /// <summary>
+    /// Defines the ListScaleEvents parameters.
+    /// </summary>
+    public class ListScaleEventsParameters
+    {
+        /// <summary>
+        /// Specifies whether only not completed events should be returned.
+        /// </summary>
+        public bool ActiveOnly { get; set; }
+
+        /// <summary>
+        /// Specifies optional region from which regions should be returned.
+        /// </summary>
+        public string FromRegion { get; set; }
+    }
+}

--- a/src/Bullfrog.Actors/ScaleManager.cs
+++ b/src/Bullfrog.Actors/ScaleManager.cs
@@ -229,6 +229,21 @@ namespace Bullfrog.Actors
             await ScheduleStateUpdate();
         }
 
+        async Task<List<RegionScaleEvent>> IScaleManager.ListEvents()
+        {
+            var events = await _events.Get();
+            return events
+                .Select(ev => new RegionScaleEvent
+                {
+                    Id = ev.Id,
+                    Name = ev.Name,
+                    RequiredScaleAt = ev.RequiredScaleAt,
+                    Scale = ev.Scale,
+                    StartScaleDownAt = ev.StartScaleDownAt,
+                })
+                .ToList();
+        }
+
         async Task IScaleManager.Disable()
         {
             await _events.Set(new List<ManagedScaleEvent>());

--- a/src/Bullfrog.Api/Controllers/ConfigurationsController.cs
+++ b/src/Bullfrog.Api/Controllers/ConfigurationsController.cs
@@ -69,12 +69,16 @@ namespace Bullfrog.Api.Controllers
         /// </summary>
         /// <param name="scaleGroup">The name of the scale group to configure.</param>
         /// <param name="definition">The new or updated configuration of the scale group.</param>
+        /// <param name="validateOnly">When enabled only validates the new configuration but not saves it.</param>
         /// <returns></returns>
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesDefaultResponseType]
         [HttpPut("{scaleGroup}")]
-        public async Task<ActionResult> SetDefinition(string scaleGroup, ScaleGroupDefinition definition)
+        public async Task<ActionResult> SetDefinition(string scaleGroup, ScaleGroupDefinition definition, bool validateOnly)
         {
+            if (validateOnly)
+                return Ok(definition);
+
             try
             {
                 await GetConfigurationManager().ConfigureScaleGroup(scaleGroup, definition);

--- a/src/Bullfrog.Api/Models/EventModels/ApiValidationFailed.cs
+++ b/src/Bullfrog.Api/Models/EventModels/ApiValidationFailed.cs
@@ -1,0 +1,15 @@
+﻿using Eshopworld.Core;
+
+namespace Bullfrog.Api.Models.EventModels
+{
+    /// <summary>
+    /// Reports API validation errors.
+    /// </summary>
+    public class ApiValidationFailed : TelemetryEvent
+    {
+        /// <summary>
+        /// The serialized validation error.
+        /// </summary>
+        public string ValidationError { get; set; }
+    }
+}

--- a/src/Tests/Bullfrog.Client/Client.json
+++ b/src/Tests/Bullfrog.Client/Client.json
@@ -95,6 +95,11 @@
             "default": ""
           },
           {
+            "in": "query",
+            "name": "validateOnly",
+            "type": "boolean"
+          },
+          {
             "in": "body",
             "name": "body",
             "schema": {

--- a/src/Tests/Bullfrog.Client/Client.json
+++ b/src/Tests/Bullfrog.Client/Client.json
@@ -182,6 +182,17 @@
             "required": true,
             "type": "string",
             "default": ""
+          },
+          {
+            "in": "query",
+            "name": "activeOnly",
+            "type": "boolean",
+            "default": false
+          },
+          {
+            "in": "query",
+            "name": "fromRegion",
+            "type": "string"
           }
         ],
         "responses": {

--- a/src/Tests/Bullfrog.Client/Client/BullfrogApi.cs
+++ b/src/Tests/Bullfrog.Client/Client/BullfrogApi.cs
@@ -957,6 +957,10 @@ namespace Client
 
         /// <param name='scaleGroup'>
         /// </param>
+        /// <param name='activeOnly'>
+        /// </param>
+        /// <param name='fromRegion'>
+        /// </param>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
         /// </param>
@@ -978,7 +982,7 @@ namespace Client
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse<IList<ScheduledScaleEvent>>> ListScheduledEventsWithHttpMessagesAsync(string scaleGroup, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<IList<ScheduledScaleEvent>>> ListScheduledEventsWithHttpMessagesAsync(string scaleGroup, bool? activeOnly = false, string fromRegion = default(string), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (scaleGroup == null)
             {
@@ -992,6 +996,8 @@ namespace Client
                 _invocationId = ServiceClientTracing.NextInvocationId.ToString();
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("scaleGroup", scaleGroup);
+                tracingParameters.Add("activeOnly", activeOnly);
+                tracingParameters.Add("fromRegion", fromRegion);
                 tracingParameters.Add("cancellationToken", cancellationToken);
                 ServiceClientTracing.Enter(_invocationId, this, "ListScheduledEvents", tracingParameters);
             }
@@ -999,6 +1005,19 @@ namespace Client
             var _baseUrl = BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "api/ScaleEvents/{scaleGroup}").ToString();
             _url = _url.Replace("{scaleGroup}", System.Uri.EscapeDataString(scaleGroup));
+            List<string> _queryParameters = new List<string>();
+            if (activeOnly != null)
+            {
+                _queryParameters.Add(string.Format("activeOnly={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(activeOnly, SerializationSettings).Trim('"'))));
+            }
+            if (fromRegion != null)
+            {
+                _queryParameters.Add(string.Format("fromRegion={0}", System.Uri.EscapeDataString(fromRegion)));
+            }
+            if (_queryParameters.Count > 0)
+            {
+                _url += "?" + string.Join("&", _queryParameters);
+            }
             // Create HTTP transport objects
             var _httpRequest = new HttpRequestMessage();
             HttpResponseMessage _httpResponse = null;

--- a/src/Tests/Bullfrog.Client/Client/BullfrogApi.cs
+++ b/src/Tests/Bullfrog.Client/Client/BullfrogApi.cs
@@ -584,6 +584,8 @@ namespace Client
 
         /// <param name='scaleGroup'>
         /// </param>
+        /// <param name='validateOnly'>
+        /// </param>
         /// <param name='body'>
         /// </param>
         /// <param name='customHeaders'>
@@ -604,7 +606,7 @@ namespace Client
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse> SetDefinitionWithHttpMessagesAsync(string scaleGroup, ScaleGroupDefinition body = default(ScaleGroupDefinition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse> SetDefinitionWithHttpMessagesAsync(string scaleGroup, bool? validateOnly = default(bool?), ScaleGroupDefinition body = default(ScaleGroupDefinition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (scaleGroup == null)
             {
@@ -622,6 +624,7 @@ namespace Client
                 _invocationId = ServiceClientTracing.NextInvocationId.ToString();
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("scaleGroup", scaleGroup);
+                tracingParameters.Add("validateOnly", validateOnly);
                 tracingParameters.Add("body", body);
                 tracingParameters.Add("cancellationToken", cancellationToken);
                 ServiceClientTracing.Enter(_invocationId, this, "SetDefinition", tracingParameters);
@@ -630,6 +633,15 @@ namespace Client
             var _baseUrl = BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "api/Configurations/{scaleGroup}").ToString();
             _url = _url.Replace("{scaleGroup}", System.Uri.EscapeDataString(scaleGroup));
+            List<string> _queryParameters = new List<string>();
+            if (validateOnly != null)
+            {
+                _queryParameters.Add(string.Format("validateOnly={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(validateOnly, SerializationSettings).Trim('"'))));
+            }
+            if (_queryParameters.Count > 0)
+            {
+                _url += "?" + string.Join("&", _queryParameters);
+            }
             // Create HTTP transport objects
             var _httpRequest = new HttpRequestMessage();
             HttpResponseMessage _httpResponse = null;

--- a/src/Tests/Bullfrog.Client/Client/BullfrogApiExtensions.cs
+++ b/src/Tests/Bullfrog.Client/Client/BullfrogApiExtensions.cs
@@ -143,9 +143,13 @@ namespace Client
             /// </param>
             /// <param name='scaleGroup'>
             /// </param>
-            public static IList<ScheduledScaleEvent> ListScheduledEvents(this IBullfrogApi operations, string scaleGroup)
+            /// <param name='activeOnly'>
+            /// </param>
+            /// <param name='fromRegion'>
+            /// </param>
+            public static IList<ScheduledScaleEvent> ListScheduledEvents(this IBullfrogApi operations, string scaleGroup, bool? activeOnly = false, string fromRegion = default(string))
             {
-                return operations.ListScheduledEventsAsync(scaleGroup).GetAwaiter().GetResult();
+                return operations.ListScheduledEventsAsync(scaleGroup, activeOnly, fromRegion).GetAwaiter().GetResult();
             }
 
             /// <param name='operations'>
@@ -153,12 +157,16 @@ namespace Client
             /// </param>
             /// <param name='scaleGroup'>
             /// </param>
+            /// <param name='activeOnly'>
+            /// </param>
+            /// <param name='fromRegion'>
+            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<IList<ScheduledScaleEvent>> ListScheduledEventsAsync(this IBullfrogApi operations, string scaleGroup, CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<IList<ScheduledScaleEvent>> ListScheduledEventsAsync(this IBullfrogApi operations, string scaleGroup, bool? activeOnly = false, string fromRegion = default(string), CancellationToken cancellationToken = default(CancellationToken))
             {
-                using (var _result = await operations.ListScheduledEventsWithHttpMessagesAsync(scaleGroup, null, cancellationToken).ConfigureAwait(false))
+                using (var _result = await operations.ListScheduledEventsWithHttpMessagesAsync(scaleGroup, activeOnly, fromRegion, null, cancellationToken).ConfigureAwait(false))
                 {
                     return _result.Body;
                 }

--- a/src/Tests/Bullfrog.Client/Client/BullfrogApiExtensions.cs
+++ b/src/Tests/Bullfrog.Client/Client/BullfrogApiExtensions.cs
@@ -70,11 +70,13 @@ namespace Client
             /// </param>
             /// <param name='scaleGroup'>
             /// </param>
+            /// <param name='validateOnly'>
+            /// </param>
             /// <param name='body'>
             /// </param>
-            public static void SetDefinition(this IBullfrogApi operations, string scaleGroup, ScaleGroupDefinition body = default(ScaleGroupDefinition))
+            public static void SetDefinition(this IBullfrogApi operations, string scaleGroup, bool? validateOnly = default(bool?), ScaleGroupDefinition body = default(ScaleGroupDefinition))
             {
-                operations.SetDefinitionAsync(scaleGroup, body).GetAwaiter().GetResult();
+                operations.SetDefinitionAsync(scaleGroup, validateOnly, body).GetAwaiter().GetResult();
             }
 
             /// <param name='operations'>
@@ -82,14 +84,16 @@ namespace Client
             /// </param>
             /// <param name='scaleGroup'>
             /// </param>
+            /// <param name='validateOnly'>
+            /// </param>
             /// <param name='body'>
             /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task SetDefinitionAsync(this IBullfrogApi operations, string scaleGroup, ScaleGroupDefinition body = default(ScaleGroupDefinition), CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task SetDefinitionAsync(this IBullfrogApi operations, string scaleGroup, bool? validateOnly = default(bool?), ScaleGroupDefinition body = default(ScaleGroupDefinition), CancellationToken cancellationToken = default(CancellationToken))
             {
-                (await operations.SetDefinitionWithHttpMessagesAsync(scaleGroup, body, null, cancellationToken).ConfigureAwait(false)).Dispose();
+                (await operations.SetDefinitionWithHttpMessagesAsync(scaleGroup, validateOnly, body, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
             /// <param name='operations'>

--- a/src/Tests/Bullfrog.Client/Client/IBullfrogApi.cs
+++ b/src/Tests/Bullfrog.Client/Client/IBullfrogApi.cs
@@ -60,6 +60,8 @@ namespace Client
 
         /// <param name='scaleGroup'>
         /// </param>
+        /// <param name='validateOnly'>
+        /// </param>
         /// <param name='body'>
         /// </param>
         /// <param name='customHeaders'>
@@ -68,7 +70,7 @@ namespace Client
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        Task<HttpOperationResponse> SetDefinitionWithHttpMessagesAsync(string scaleGroup, ScaleGroupDefinition body = default(ScaleGroupDefinition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse> SetDefinitionWithHttpMessagesAsync(string scaleGroup, bool? validateOnly = default(bool?), ScaleGroupDefinition body = default(ScaleGroupDefinition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <param name='scaleGroup'>
         /// </param>

--- a/src/Tests/Bullfrog.Client/Client/IBullfrogApi.cs
+++ b/src/Tests/Bullfrog.Client/Client/IBullfrogApi.cs
@@ -92,13 +92,17 @@ namespace Client
 
         /// <param name='scaleGroup'>
         /// </param>
+        /// <param name='activeOnly'>
+        /// </param>
+        /// <param name='fromRegion'>
+        /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        Task<HttpOperationResponse<IList<ScheduledScaleEvent>>> ListScheduledEventsWithHttpMessagesAsync(string scaleGroup, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<IList<ScheduledScaleEvent>>> ListScheduledEventsWithHttpMessagesAsync(string scaleGroup, bool? activeOnly = false, string fromRegion = default(string), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <param name='scaleGroup'>
         /// </param>

--- a/src/Tests/Bullfrog.Tests/ConfigurationControllerTests.cs
+++ b/src/Tests/Bullfrog.Tests/ConfigurationControllerTests.cs
@@ -26,7 +26,7 @@ public class ConfigurationControllerTests : BaseApiTests
     public async Task CreateNewScaleGroup()
     {
         //act
-        await ApiClient.SetDefinitionAsync("sg", new ScaleGroupDefinition
+        await ApiClient.SetDefinitionAsync("sg", body: new ScaleGroupDefinition
         {
             Regions = new List<ScaleGroupRegion>
             {
@@ -83,10 +83,10 @@ public class ConfigurationControllerTests : BaseApiTests
                 }
             },
         };
-        await ApiClient.SetDefinitionAsync("sg", scaleGroup);
+        await ApiClient.SetDefinitionAsync("sg", body: scaleGroup);
 
         //act
-        await ApiClient.SetDefinitionAsync("sg", scaleGroup);
+        await ApiClient.SetDefinitionAsync("sg", body: scaleGroup);
     }
 
     [Fact, IsLayer0]
@@ -110,7 +110,7 @@ public class ConfigurationControllerTests : BaseApiTests
                 },
             },
         };
-        await ApiClient.SetDefinitionAsync("sg", scaleGroup);
+        await ApiClient.SetDefinitionAsync("sg", body: scaleGroup);
         await ApiClient.SaveScaleEventAsync("sg", Guid.NewGuid(), new ScaleEvent
         {
             Name = "n",
@@ -121,7 +121,7 @@ public class ConfigurationControllerTests : BaseApiTests
         scaleGroup.Regions.RemoveAt(1); // try to remove eu2
 
         //act
-        Func<Task> call = () => ApiClient.SetDefinitionAsync("sg", scaleGroup);
+        Func<Task> call = () => ApiClient.SetDefinitionAsync("sg", body: scaleGroup);
 
         call.Should().Throw<ProblemDetailsException>();
     }
@@ -147,7 +147,7 @@ public class ConfigurationControllerTests : BaseApiTests
                 },
             },
         };
-        await ApiClient.SetDefinitionAsync("sg", scaleGroup);
+        await ApiClient.SetDefinitionAsync("sg", body: scaleGroup);
         await ApiClient.SaveScaleEventAsync("sg", Guid.NewGuid(), new ScaleEvent
         {
             Name = "n",
@@ -158,7 +158,7 @@ public class ConfigurationControllerTests : BaseApiTests
         scaleGroup.Regions.RemoveAt(1); // try to remove eu2
 
         //act
-        await ApiClient.SetDefinitionAsync("sg", scaleGroup);
+        await ApiClient.SetDefinitionAsync("sg", body: scaleGroup);
     }
 
     [Fact, IsLayer0]
@@ -176,7 +176,7 @@ public class ConfigurationControllerTests : BaseApiTests
                 }
             },
         };
-        await ApiClient.SetDefinitionAsync("sg", scaleGroup);
+        await ApiClient.SetDefinitionAsync("sg", body: scaleGroup);
 
         //act
         await ApiClient.RemoveDefinitionAsync("sg");
@@ -201,7 +201,7 @@ public class ConfigurationControllerTests : BaseApiTests
                 }
             },
         };
-        await ApiClient.SetDefinitionAsync("sg", scaleGroup);
+        await ApiClient.SetDefinitionAsync("sg", body: scaleGroup);
 
         //act
         Func<Task> func = () => ApiClient.GetDefinitionAsync("unkn");
@@ -225,7 +225,7 @@ public class ConfigurationControllerTests : BaseApiTests
                 }
             },
         };
-        await ApiClient.SetDefinitionAsync("sg", scaleGroup);
+        await ApiClient.SetDefinitionAsync("sg", body: scaleGroup);
 
         //act
         var returnedScaleGroup = await ApiClient.GetDefinitionAsync("sg");

--- a/src/Tests/Bullfrog.Tests/MaxScaleTests.cs
+++ b/src/Tests/Bullfrog.Tests/MaxScaleTests.cs
@@ -115,7 +115,7 @@ public class MaxScaleTests : BaseApiTests
 
     private async Task CreateScaleGroup()
     {
-        await ApiClient.SetDefinitionAsync("sg", NewScaleGroupDefinition());
+        await ApiClient.SetDefinitionAsync("sg", body: NewScaleGroupDefinition());
     }
 
     private static ScaleGroupDefinition NewScaleGroupDefinition()

--- a/src/Tests/Bullfrog.Tests/MultiRegionDomainEventTests.cs
+++ b/src/Tests/Bullfrog.Tests/MultiRegionDomainEventTests.cs
@@ -113,7 +113,7 @@ public class MultiRegionDomainEventTests : BaseApiTests
 
     private void CreateScaleGroup(ScaleGroupDefinition scaleGroupDefinition = null)
     {
-        ApiClient.SetDefinition("sg", scaleGroupDefinition ?? NewScaleGroupDefinition());
+        ApiClient.SetDefinition("sg", body: scaleGroupDefinition ?? NewScaleGroupDefinition());
     }
 
     private static ScaleGroupDefinition NewScaleGroupDefinition()

--- a/src/Tests/Bullfrog.Tests/MultiRegionScaleGroupTests.cs
+++ b/src/Tests/Bullfrog.Tests/MultiRegionScaleGroupTests.cs
@@ -128,7 +128,7 @@ public class MultiRegionScaleGroupTests : BaseApiTests
 
     private void CreateScaleGroup(ScaleGroupDefinition scaleGroupDefinition = null)
     {
-        ApiClient.SetDefinition("sg", scaleGroupDefinition ?? NewScaleGroupDefinition());
+        ApiClient.SetDefinition("sg", body: scaleGroupDefinition ?? NewScaleGroupDefinition());
     }
 
     private static ScaleGroupDefinition NewScaleGroupDefinition()

--- a/src/Tests/Bullfrog.Tests/ScaleChangedDomainEventTests.cs
+++ b/src/Tests/Bullfrog.Tests/ScaleChangedDomainEventTests.cs
@@ -192,7 +192,7 @@ public class ScaleChangedDomainEventTests : BaseApiTests
 
     private void CreateScaleGroup()
     {
-        ApiClient.SetDefinition("sg", new ScaleGroupDefinition
+        ApiClient.SetDefinition("sg", body: new ScaleGroupDefinition
         {
             Regions = new List<ScaleGroupRegion>
             {

--- a/src/Tests/Bullfrog.Tests/ScaleEventOperationsTests.cs
+++ b/src/Tests/Bullfrog.Tests/ScaleEventOperationsTests.cs
@@ -242,7 +242,7 @@ public class ScaleEventOperationsTests : BaseApiTests
 
     private void CreateScaleGroup(ScaleGroupDefinition scaleGroupDefinition = null)
     {
-        ApiClient.SetDefinition("sg", scaleGroupDefinition ?? NewScaleGroupDefinition());
+        ApiClient.SetDefinition("sg", body: scaleGroupDefinition ?? NewScaleGroupDefinition());
     }
 
     private static ScaleGroupDefinition NewScaleGroupDefinition()

--- a/src/Tests/Bullfrog.Tests/ScaleGroupStateTests.cs
+++ b/src/Tests/Bullfrog.Tests/ScaleGroupStateTests.cs
@@ -82,7 +82,7 @@ public class ScaleGroupStateTests : BaseApiTests
 
     private void CreateScaleGroup(ScaleGroupDefinition scaleGroupDefinition = null)
     {
-        ApiClient.SetDefinition("sg", scaleGroupDefinition ?? NewScaleGroupDefinition());
+        ApiClient.SetDefinition("sg", body: scaleGroupDefinition ?? NewScaleGroupDefinition());
     }
 
     private static ScaleGroupDefinition NewScaleGroupDefinition()

--- a/src/Tests/Bullfrog.Tests/ScaleManagerTests.cs
+++ b/src/Tests/Bullfrog.Tests/ScaleManagerTests.cs
@@ -345,7 +345,7 @@ public class ScaleManagerTests : BaseApiTests
 
     private void CreateScaleGroup()
     {
-        ApiClient.SetDefinition("sg", new Client.Models.ScaleGroupDefinition
+        ApiClient.SetDefinition("sg", body: new Client.Models.ScaleGroupDefinition
         {
             Regions = new List<ScaleGroupRegion>
             {

--- a/src/Tests/Bullfrog.Tests/ScaleManagerTests.cs
+++ b/src/Tests/Bullfrog.Tests/ScaleManagerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Client;
 using Client.Models;
@@ -112,6 +113,110 @@ public class ScaleManagerTests : BaseApiTests
         var actor = ScaleManagerActors[("sg", "eu")];
         var reminders = actor.GetActorReminders();
         reminders.Should().HaveCount(1);
+    }
+
+    [Fact, IsLayer0]
+    public void ListReturnsOrderedScaleEvents()
+    {
+        CreateScaleGroup();
+        var events = new (int start, int end)[] { (1, 2), (4, 6), (2, 8), (4, 5), };
+        foreach (var rng in events)
+        {
+            var scaleEvent = new ScaleEvent
+            {
+                Name = "aa",
+                RegionConfig = new List<RegionScaleValue>
+            {
+                new RegionScaleValue
+                {
+                    Name = "eu",
+                    Scale = 10,
+                }
+            },
+                RequiredScaleAt = UtcNow + TimeSpan.FromHours(rng.start),
+                StartScaleDownAt = UtcNow + TimeSpan.FromHours(rng.end),
+            };
+            ApiClient.SaveScaleEvent("sg", Guid.NewGuid(), scaleEvent);
+        }
+
+        var allScaleEvents = ApiClient.ListScheduledEvents("sg");
+
+        var returnedEventStartEnds = allScaleEvents.Select(ev => ToStartEnd(ev));
+        var ordered = events.OrderBy(ev => ev.start).ThenBy(ev => ev.end);
+        returnedEventStartEnds.Should().ContainInOrder(ordered);
+
+        (int start, int end) ToStartEnd(ScheduledScaleEvent ev)
+            => ((int)(ev.RequiredScaleAt.Value - UtcNow).TotalHours, (int)(ev.StartScaleDownAt.Value - UtcNow).TotalHours);
+    }
+
+    [Fact, IsLayer0]
+    public async Task OnlyActiveEventsAreReturned()
+    {
+        CreateScaleGroup();
+        var events = new (int start, int end)[] { (2, 8), (4, 5), (3, 7), (6, 7) };
+        foreach (var rng in events)
+        {
+            var scaleEvent = new ScaleEvent
+            {
+                Name = "aa",
+                RegionConfig = new List<RegionScaleValue>
+                {
+                    new RegionScaleValue
+                    {
+                        Name = "eu",
+                        Scale = 10,
+                    }
+                },
+                RequiredScaleAt = UtcNow + TimeSpan.FromHours(rng.start),
+                StartScaleDownAt = UtcNow + TimeSpan.FromHours(rng.end),
+            };
+            ApiClient.SaveScaleEvent("sg", Guid.NewGuid(), scaleEvent);
+        }
+        await AdvanceTimeTo(UtcNow.AddHours(4));
+
+        var allScaleEvents = ApiClient.ListScheduledEvents("sg", activeOnly: true);
+
+        var returnedEventStartEnds = allScaleEvents.Select(ev => ToStartEnd(ev));
+        var ordered = events
+            .Select(ev => (start: ev.start - 4, end: ev.end - 4))
+            .Where(ev => ev.end >= 0)
+            .OrderBy(ev => ev.start)
+            .ThenBy(ev => ev.end);
+        returnedEventStartEnds.Should().ContainInOrder(ordered);
+
+        (int start, int end) ToStartEnd(ScheduledScaleEvent ev)
+            => ((int)(ev.RequiredScaleAt.Value - UtcNow).TotalHours, (int)(ev.StartScaleDownAt.Value - UtcNow).TotalHours);
+    }
+
+    [Fact, IsLayer0]
+    public async Task ListReturnsEventsFromSelectedRegion()
+    {
+        CreateScaleGroup();
+        var events = new (int start, int end, string regions)[] { (2, 8, "eu"), (4, 5, "eu1,eu"), (3, 7, "eu1"), (6, 7, "eu") };
+        foreach (var rng in events)
+        {
+            var scaleEvent = new ScaleEvent
+            {
+                Name = "aa",
+                RegionConfig = rng.regions.Split(',')
+                    .Select(r => new RegionScaleValue { Name = r, Scale = 10 })
+                    .ToList(),
+                RequiredScaleAt = UtcNow + TimeSpan.FromHours(rng.start),
+                StartScaleDownAt = UtcNow + TimeSpan.FromHours(rng.end),
+            };
+            ApiClient.SaveScaleEvent("sg", Guid.NewGuid(), scaleEvent);
+        }
+
+        var allScaleEvents = ApiClient.ListScheduledEvents("sg", fromRegion: "eu1");
+
+        var returnedEventStartEnds = allScaleEvents.Select(ev => ToStartEnd(ev));
+        var ordered = events.Where(ev => ev.regions.Contains("eu1"))
+            .Select(ev=>(ev.start, ev.end))
+            .OrderBy(ev => ev.start).ThenBy(ev => ev.end);
+        returnedEventStartEnds.Should().ContainInOrder(ordered);
+
+        (int start, int end) ToStartEnd(ScheduledScaleEvent ev)
+            => ((int)(ev.RequiredScaleAt.Value - UtcNow).TotalHours, (int)(ev.StartScaleDownAt.Value - UtcNow).TotalHours);
     }
 
     [Fact, IsLayer0]
@@ -367,6 +472,24 @@ public class ScaleManagerTests : BaseApiTests
                             }
                         },
                     },
+                    ScaleSets = new List<ScaleSetConfiguration>
+                    {
+                        new ScaleSetConfiguration
+                        {
+                            Name = "s",
+                            AutoscaleSettingsResourceId = GetAutoscaleSettingResourceId(),
+                            ProfileName = "pr",
+                            LoadBalancerResourceId = GetLoadBalancerResourceId(),
+                            HealthPortPort = 9999,
+                            RequestsPerInstance = 100,
+                        },
+                    },
+                    CosmosDbPrescaleLeadTime = _cosmosDbPrescaleLeadTime.ToString(),
+                    ScaleSetPrescaleLeadTime = _scaleSetPrescaleLeadTime.ToString(),
+                },
+                new ScaleGroupRegion
+                {
+                    RegionName = "eu1",
                     ScaleSets = new List<ScaleSetConfiguration>
                     {
                         new ScaleSetConfiguration

--- a/src/Tests/Bullfrog.Tests/SharedCosmosDbTests.cs
+++ b/src/Tests/Bullfrog.Tests/SharedCosmosDbTests.cs
@@ -72,7 +72,7 @@ public class SharedCosmosDbTests : BaseApiTests
         ApiClient.SaveScaleEvent("sg", eventId, NewScaleEvent());
         var updatedConfiguration = NewScaleGroupDefinition();
         updatedConfiguration.Cosmos = null;
-        ApiClient.SetDefinition("sg", updatedConfiguration);
+        ApiClient.SetDefinition("sg", body: updatedConfiguration);
 
         await AdvanceTimeTo(UtcNow.AddHours(15));
 
@@ -110,7 +110,7 @@ public class SharedCosmosDbTests : BaseApiTests
     {
         if (scaleGroupDefinition == null)
             scaleGroupDefinition = NewScaleGroupDefinition();
-        ApiClient.SetDefinition("sg", scaleGroupDefinition);
+        ApiClient.SetDefinition("sg", body: scaleGroupDefinition);
         var allResources = scaleGroupDefinition.Cosmos.Select(x => x.Name)
             .Union(scaleGroupDefinition.Regions.SelectMany(r => r.ScaleSets).Select(x => x.Name));
         foreach (var resources in allResources)


### PR DESCRIPTION
Because validation of configuration changes can take more than the connection time limit imposed by network infrastructure all model validation errors are now logged.
Additionally it's possible now to test a new configuration without updating an existing one.