### PR TITLE
Downgrade of SF libraries to v. 4.0.470

### DIFF
--- a/src/Bullfrog.Actors.Interfaces/Bullfrog.Actors.Interfaces.csproj
+++ b/src/Bullfrog.Actors.Interfaces/Bullfrog.Actors.Interfaces.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/Bullfrog.Actors/Bullfrog.Actors.csproj
+++ b/src/Bullfrog.Actors/Bullfrog.Actors.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.34.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.5" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.1" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.417" />  </ItemGroup>
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Bullfrog.Actors.Interfaces\Bullfrog.Actors.Interfaces.csproj" />

--- a/src/Bullfrog.Api/Bullfrog.Api.csproj
+++ b/src/Bullfrog.Api/Bullfrog.Api.csproj
@@ -29,8 +29,8 @@
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.417" />
-    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />
+    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="4.0.470" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
   </ItemGroup>
 

--- a/src/Bullfrog.Common/Bullfrog.Common.csproj
+++ b/src/Bullfrog.Common/Bullfrog.Common.csproj
@@ -24,7 +24,7 @@
     <!-- Reference to ActiveDirectory nuget can be removed after the https://github.com/Azure/azure-sdk-for-net/issues/6458 issue is fixed. -->
     <!-- Conflict between Microsoft.Azure.Services.AppAuthentication 1.3.1 and Microsoft.Azure.Management.Fluent 1.24.1 (the later requires <4.0.0)-->
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.7" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Bullfrog.Tests/Bullfrog.Tests.csproj
+++ b/src/Tests/Bullfrog.Tests/Bullfrog.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.4" />
-    <PackageReference Include="ServiceFabric.Mocks" Version="4.1.5" />
+    <PackageReference Include="ServiceFabric.Mocks" Version="4.1.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
We are downgrading SF libraries to v. 4.0.470 until the cluster are upgraded to v.7.1.x due to incompatibility.