### PR TITLE
#88698 Add HEAD support for Probe request

### DIFF
--- a/src/Bullfrog.Api/Controllers/ProbeController.cs
+++ b/src/Bullfrog.Api/Controllers/ProbeController.cs
@@ -14,6 +14,7 @@ namespace Bullfrog.Api.Controllers
         /// probe endpoint
         /// </summary>
         [HttpGet]
+        [HttpHead]
         public IActionResult Get()
         {
             return Ok();


### PR DESCRIPTION
Adding support for HEAD probes as the app is currently configured for GET probes on AFD. Will remove GET support when DevOps updates AFD configuration. Discussed with Colin in DevOps.